### PR TITLE
chore: complete repository community baseline

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,8 @@
 blank_issues_enabled: false
+contact_links:
+  - name: Support guide
+    url: https://github.com/montasim/ramadan-clock/blob/main/SUPPORT.md
+    about: Find the right place for usage questions, bugs, feature requests, and schedule discrepancies.
+  - name: Security vulnerability
+    url: https://github.com/montasim/ramadan-clock/security/policy
+    about: Read the private reporting instructions; do not disclose vulnerabilities in a public issue.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Asia/Dhaka"
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 3
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Ramadan Clock is a pre-release public project. Keep these constraints in mind:
 
 ## Support and security
 
-Use [GitHub Issues](https://github.com/montasim/ramadan-clock/issues) for reproducible bugs and feature requests. Include the affected route, district, date, expected result, and actual result where relevant. Never post credentials, database URLs, private information, or other secrets in an issue.
+Read the [support guide](SUPPORT.md) to choose the right channel. Use [GitHub Issues](https://github.com/montasim/ramadan-clock/issues) for reproducible bugs and feature requests. Include the affected route, district, date, expected result, and actual result where relevant. Never post credentials, database URLs, private information, or other secrets in an issue.
 
 Report vulnerabilities privately according to the [security policy](SECURITY.md), not through a public issue.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,35 @@
+# Support
+
+Thank you for using Ramadan Clock. This guide directs questions and reports to the channel where they can be handled most effectively.
+
+## Before opening an issue
+
+1. Read the [README](README.md) and relevant files in [`docs/`](docs/).
+2. Search [existing issues](https://github.com/montasim/ramadan-clock/issues) for the same problem.
+3. Confirm the problem still occurs on the latest public deployment or the latest revision of `main`.
+
+## Choose the right channel
+
+| Need | Where to go |
+| --- | --- |
+| Reproducible application bug | [Open the issue chooser](https://github.com/montasim/ramadan-clock/issues/new/choose) and select **Bug report** |
+| Prayer-time discrepancy | Use **Bug report** and include the district, date, displayed time, expected time, trusted timetable, and calculation source |
+| Feature or improvement | [Open the issue chooser](https://github.com/montasim/ramadan-clock/issues/new/choose) and select **Feature request** |
+| Security vulnerability | Follow [SECURITY.md](SECURITY.md); do not open a public issue |
+| Contribution question | Read [CONTRIBUTING.md](CONTRIBUTING.md), then comment on the related issue or pull request |
+
+## Include useful details
+
+For technical problems, provide:
+
+- A clear description of the actual and expected behavior
+- Reproduction steps
+- The affected route, district, and date when relevant
+- Browser, device, operating system, or Node.js version
+- Screenshots or sanitized logs when they help explain the problem
+
+Never include passwords, authentication secrets, database URLs, private user information, or production data.
+
+## Support expectations
+
+Ramadan Clock is a community-maintained, pre-release project. Support is provided on a best-effort basis, with no guaranteed response or resolution time. Well-scoped reports with complete reproduction details are easier to investigate.


### PR DESCRIPTION
## Summary

- add a weekly npm/pnpm Dependabot policy with grouped minor and patch updates while keeping major upgrades separate
- add monthly GitHub Actions dependency updates
- add a dedicated support guide with clear routes for bugs, schedule discrepancies, feature requests, security reports, and contribution questions
- surface support and security guidance in the GitHub issue chooser
- link the support guide from the README

The repository's public GitHub description was also corrected separately to reference PostgreSQL and Prisma instead of MongoDB.

## Verification

- Dependabot and issue-chooser YAML parses successfully
- community-document Markdown structure is valid
- all local README and support-guide links resolve
- issue chooser and security policy destinations return HTTP 200
- `pnpm lint` — 0 errors (76 existing warnings)
- `pnpm type-check`
- `pnpm test` — 5 tests passed

## Notes

- Dependabot alerts are enabled for the repository.
- Dependabot security updates are enabled but currently paused; merging this configuration should register repository activity and allow updates to resume.
- Existing security alerts still require prioritization and review; this configuration does not automatically merge dependency changes.
